### PR TITLE
post error message from server to chat on rename

### DIFF
--- a/api.go
+++ b/api.go
@@ -68,7 +68,15 @@ func (b *bot) renameUser(oldName string, newName string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("status code %d, %s", resp.StatusCode, body)
+		unmarshalled := map[string]interface{}{}
+		if err := json.Unmarshal(body, &unmarshalled); err != nil {
+			return fmt.Errorf("failed to unmarshal response: %v", err)
+		}
+		msg, ok := unmarshalled["message"].(string)
+		if !ok {
+			return fmt.Errorf("status code %d, %s", resp.StatusCode, body)
+		}
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -135,9 +135,11 @@ func (b *bot) rename(m dggchat.Message, s *dggchat.Session) {
 	newName := parts[2]
 	err := b.renameUser(oldName, newName)
 	if err != nil {
-		log.Printf("[##] rename: '%s' to '%s' by %s failed with '%s'\n",
+		msg := fmt.Sprintf("'%s' to '%s' by %s failed with '%s'",
 			oldName, newName, m.Sender.Nick, err.Error())
+		log.Printf("[##] rename: %s\n", msg)
 
+		s.SendPrivateMessage(msg, m.Sender.Nick)
 		b.sendMessageDedupe("rename error, check logs", s)
 		return
 	}


### PR DESCRIPTION
```
2021/07/11 20:21:13 [##] rename: 'matthew' to 'matt' by jbpratt failed with 'status code 400, {"code":6,"message":"Name unavailable.","details":""}'
```