### PR TITLE
Add sudoku command to allow users to self mute honorably without spam

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -108,6 +108,14 @@ func (b *bot) nuke(m dggchat.Message, s *dggchat.Session) {
 	b.lastNukeVictims = append(b.lastNukeVictims, victimNames...)
 }
 
+func (b *bot) sudoku(m dggchat.Message, s *dggchat.Session) {
+	if !strings.HasPrefix(m.Message, "!sudoku") {
+		return
+	}
+        // TODO duration, -1 means server default
+        s.SendMute(m.Sender.Nick, -1)
+}
+
 // !aegis - undo (all) past nukes
 func (b *bot) aegis(m dggchat.Message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!aegis") || b.lastNukeVictims == nil {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 		b.dropAT,
 		b.provideAltAngelthumpLink,
 		b.ban,
+                b.sudoku,
 	)
 	dgg.AddMessageHandler(b.onMessage)
 	dgg.AddErrorHandler(b.onError)


### PR DESCRIPTION
If any user types `!sudoku` at the start of a message they will be muted for the server default length. This allows a user to achieve their desired muted status without sending 5 messages in a row.