### PR TITLE
fix: persist command deletion via !addcommand _

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -226,7 +226,12 @@ func (b *bot) addCommand(m dggchat.Message, s *dggchat.Session) {
 	// TODO workaround to enable deletion
 	if resp == "_" {
 		delete(commands, cmnd)
-		b.sendMessageDedupe("deleted commands if it existed", s)
+		success := saveStaticCommands()
+		if success {
+			b.sendMessageDedupe("deleted command if it existed", s)
+			return
+		}
+		b.sendMessageDedupe("failed saving command, check logs", s)
 	} else {
 		commands[cmnd] = resp
 		success := saveStaticCommands()


### PR DESCRIPTION
Deleting a command with !addcommand <name> _ removed it from the in-memory map but never called saveStaticCommands(), so the deletion was lost on restart and the old command would reload from disk.