### PR TITLE
feat: add !imdb command backed by OMDb

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@
 | --- | --- | --- | ---- |
 | !stream\|!strim | _ | | Prints lists of top streams.
 | !check | AT_name | !check test | Check status of an AT stream.
+| !imdb | [-tv\|-s] title [year] | !imdb dune 2021 | Looks up a movie by default; `-tv` looks up a series instead; `-s` searches and lists up to 5 matches. Requires `-omdbkey` to be set.
 
 All mod-commands can also be issued via PMs to Bot. E.g. `/w Bot !modify youtube/6n3pFFPSlW4 hidden !nsfw`. Responses will be via normal chat though!

--- a/api.go
+++ b/api.go
@@ -183,6 +183,85 @@ func (b *bot) getStreamList() (streamData, error) {
 	return sd, nil
 }
 
+const omdbURL = "https://www.omdbapi.com/"
+
+type omdbResp struct {
+	Title      string `json:"Title"`
+	Year       string `json:"Year"`
+	ImdbID     string `json:"imdbID"`
+	ImdbRating string `json:"imdbRating"`
+	Response   string `json:"Response"`
+	Error      string `json:"Error"`
+}
+
+type omdbSearchResp struct {
+	Search []struct {
+		Title  string `json:"Title"`
+		Year   string `json:"Year"`
+		ImdbID string `json:"imdbID"`
+		Type   string `json:"Type"`
+	} `json:"Search"`
+	Response string `json:"Response"`
+	Error    string `json:"Error"`
+}
+
+// issue a GET against OMDb with the given query params (apikey is added automatically)
+func omdbGet(params map[string]string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, omdbURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	q.Set("apikey", omdbAPIKey)
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	client := &http.Client{Timeout: apiRequestTimeout}
+	return client.Do(req)
+}
+
+// direct title lookup, scoped to a media type (movie/series) and optionally a release year
+func getIMDbInfo(query string, year string, mediaType string) (omdbResp, error) {
+	params := map[string]string{"t": query, "type": mediaType}
+	if year != "" {
+		params["y"] = year
+	}
+	resp, err := omdbGet(params)
+	if err != nil {
+		return omdbResp{}, err
+	}
+	defer resp.Body.Close()
+
+	var or omdbResp
+	if err := json.NewDecoder(resp.Body).Decode(&or); err != nil {
+		return omdbResp{}, err
+	}
+	if or.Response == "False" {
+		return omdbResp{}, fmt.Errorf("%s", or.Error)
+	}
+	return or, nil
+}
+
+// search titles matching the free-text query, scoped to a media type (movie/series)
+func searchIMDb(query string, mediaType string) (omdbSearchResp, error) {
+	resp, err := omdbGet(map[string]string{"s": query, "type": mediaType})
+	if err != nil {
+		return omdbSearchResp{}, err
+	}
+	defer resp.Body.Close()
+
+	var sr omdbSearchResp
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return omdbSearchResp{}, err
+	}
+	if sr.Response == "False" {
+		return omdbSearchResp{}, fmt.Errorf("%s", sr.Error)
+	}
+	return sr, nil
+}
+
 // at api data
 type atData struct {
 	ViewerCount int `json:"viewer_count"`

--- a/commands.go
+++ b/commands.go
@@ -238,6 +238,82 @@ func (b *bot) addCommand(m dggchat.Message, s *dggchat.Session) {
 	}
 }
 
+var trailingYearRegexp = regexp.MustCompile(`^(.*\S)\s+(\d{4})$`)
+
+// !imdb [-tv|-s] title [year] -- look up a movie/show and print title (year) - rating - link
+// defaults to a direct movie lookup; -tv looks up a series instead; -s searches and lists matches
+func (b *bot) imdb(m dggchat.Message, s *dggchat.Session) {
+	if !strings.HasPrefix(m.Message, "!imdb") {
+		return
+	}
+
+	if omdbAPIKey == "" {
+		b.sendMessageDedupe("imdb lookup not configured", s)
+		return
+	}
+
+	parts := strings.SplitN(m.Message, " ", 2)
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		b.sendMessageDedupe("usage: !imdb [-tv|-s] <title> [year]", s)
+		return
+	}
+	rest := strings.TrimSpace(parts[1])
+
+	mediaType := "movie"
+	search := false
+	switch {
+	case strings.HasPrefix(rest, "-tv "):
+		mediaType = "series"
+		rest = strings.TrimSpace(rest[len("-tv "):])
+	case strings.HasPrefix(rest, "-s "):
+		search = true
+		rest = strings.TrimSpace(rest[len("-s "):])
+	}
+	if rest == "" {
+		b.sendMessageDedupe("usage: !imdb [-tv|-s] <title> [year]", s)
+		return
+	}
+
+	if search {
+		sr, err := searchIMDb(rest, mediaType)
+		if err != nil {
+			b.sendMessageDedupe(fmt.Sprintf("imdb: %s", err.Error()), s)
+			return
+		}
+		max := len(sr.Search)
+		if max > 5 {
+			max = 5
+		}
+		matches := make([]string, 0, max)
+		for _, item := range sr.Search[:max] {
+			matches = append(matches, fmt.Sprintf("%s (%s)", item.Title, item.Year))
+		}
+		b.sendMessageDedupe(strings.Join(matches, ", "), s)
+		return
+	}
+
+	title, year := rest, ""
+	if match := trailingYearRegexp.FindStringSubmatch(rest); match != nil {
+		title, year = match[1], match[2]
+	}
+
+	info, err := getIMDbInfo(title, year, mediaType)
+	if err != nil {
+		b.sendMessageDedupe(fmt.Sprintf("imdb: %s", err.Error()), s)
+		return
+	}
+	b.sendMessageDedupe(formatIMDbInfo(info), s)
+}
+
+func formatIMDbInfo(info omdbResp) string {
+	rating := info.ImdbRating
+	if rating == "" || rating == "N/A" {
+		rating = "no rating"
+	}
+	link := fmt.Sprintf("https://www.imdb.com/title/%s", info.ImdbID)
+	return fmt.Sprintf("%s (%s) - %s - %s", info.Title, info.Year, rating, link)
+}
+
 // TOOD clean up...
 func isCommunityStream(path string) bool {
 	// "/twitch/test" it not. "/memer" is.

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	logFileName  string
 	commandJSON  string
 	atAdminToken string
+	omdbAPIKey   string
 	logOnly      bool
 	logFile      *os.File
 )
@@ -43,6 +44,7 @@ func main() {
 	flag.StringVar(&logFileName, "log", "/tmp/chatlog/chatlog.log", "file to write messages to")
 	flag.StringVar(&commandJSON, "commands", "commands.json", "static commands file")
 	flag.StringVar(&atAdminToken, "attoken", "", "angelthump admin token (optional)")
+	flag.StringVar(&omdbAPIKey, "omdbkey", "", "OMDb API key for !imdb command (optional)")
 	flag.BoolVar(&logOnly, "logonly", false, "only 'reply' to logfile, not chat (for debugging)")
 	flag.Parse()
 
@@ -73,6 +75,7 @@ func main() {
 		b.ban,
 		b.sudoku,
 		b.roll,
+		b.imdb,
 	)
 	dgg.AddMessageHandler(b.onMessage)
 	dgg.AddErrorHandler(b.onError)


### PR DESCRIPTION
Public command for looking up movies/shows: `!imdb [-tv|-s] <title> [year]`

Defaults to a direct movie lookup, -tv scopes to series, -s lists up to 5 search matches so users can disambiguate titles with several releases (e.g. "dune") instead of silently getting an arbitrary match. Requires an OMDb API key via the new -omdbkey flag.

I can provide an https://www.omdbapi.com/ api key (they're free) or you can get one and set it in the env var. I tested this with my own key.