### PR TITLE
Split add/delete command handling & use abs filepath

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -228,43 +228,65 @@ func (b *bot) unmute(m message, s *dggchat.Session) {
 	s.SendUnmute(parts[1])
 }
 
+// normalizeCommandName splits "!addcommand foo bar baz" style messages into
+// the command prefix, the command name (always "!"-prefixed), and everything
+// after it. ok is false if fewer than minParts whitespace-separated fields
+// are present (extra whitespace collapses instead of shifting field indices).
+func normalizeCommandName(msg string, minParts int) (cmnd string, rest []string, ok bool) {
+	parts := strings.Fields(msg)
+	if len(parts) < minParts {
+		return "", nil, false
+	}
+	cmnd = parts[1]
+	if !strings.HasPrefix(cmnd, "!") {
+		cmnd = "!" + cmnd
+	}
+	return cmnd, parts[2:], true
+}
+
 // !addcommand command response
 func (b *bot) addCommand(m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!addcommand") {
 		return
 	}
 
-	// message itself can contain spaces
-	parts := strings.Split(m.Message, " ")
-	if len(parts) < 3 {
+	cmnd, respParts, ok := normalizeCommandName(m.Message, 3)
+	if !ok {
+		return
+	}
+	resp := strings.Join(respParts, " ")
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	commands[cmnd] = resp
+	success := saveStaticCommands()
+	if success {
+		b.sendMessageDedupe(m, fmt.Sprintf("added new command %s", cmnd), s)
+		return
+	}
+	b.sendMessageDedupe(m, "failed saving command, check logs", s)
+}
+
+// !delcommand command
+func (b *bot) delCommand(m message, s *dggchat.Session) {
+	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!delcommand") {
 		return
 	}
 
-	cmnd := parts[1]
-	if !strings.HasPrefix(cmnd, "!") {
-		cmnd = "!" + cmnd
+	cmnd, _, ok := normalizeCommandName(m.Message, 2)
+	if !ok {
+		return
 	}
-	resp := strings.Join(parts[2:], " ")
+
 	mutex.Lock()
 	defer mutex.Unlock()
-	// TODO workaround to enable deletion
-	if resp == "_" {
-		delete(commands, cmnd)
-		success := saveStaticCommands()
-		if success {
-			b.sendMessageDedupe(m, "deleted command if it existed", s)
-			return
-		}
-		b.sendMessageDedupe(m, "failed saving command, check logs", s)
-	} else {
-		commands[cmnd] = resp
-		success := saveStaticCommands()
-		if success {
-			b.sendMessageDedupe(m, fmt.Sprintf("added new command %s", cmnd), s)
-			return
-		}
-		b.sendMessageDedupe(m, "failed saving command, check logs", s)
+	delete(commands, cmnd)
+	success := saveStaticCommands()
+	if success {
+		b.sendMessageDedupe(m, fmt.Sprintf("deleted command %s if it existed", cmnd), s)
+		return
 	}
+	b.sendMessageDedupe(m, "failed saving command, check logs", s)
 }
 
 var trailingYearRegexp = regexp.MustCompile(`^(.*\S)\s+(\d{4})$`)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -66,6 +67,7 @@ func main() {
 		b.rename,
 		b.say,
 		b.addCommand,
+		b.delCommand,
 		b.mute,
 		b.unmute,
 		b.printTopStreams,
@@ -171,9 +173,16 @@ func fileExists(name string) bool {
 }
 
 func loadStaticCommands() {
+	// resolved to an absolute path so deploy logs show exactly which file/volume
+	// is in play -- the flag default is a bare relative name and silently
+	// follows whatever the process's CWD happens to be on a given deploy.
+	absPath, err := filepath.Abs(commandJSON)
+	if err != nil {
+		absPath = commandJSON
+	}
+
 	if !fileExists(commandJSON) {
-		log.Printf("creating empty commands file %s\n", commandJSON)
-		os.Create(commandJSON)
+		log.Printf("commands file %s not found, creating empty one\n", absPath)
 		err := ioutil.WriteFile(commandJSON, []byte("{}"), 0o755)
 		if err != nil {
 			panic(err)
@@ -190,6 +199,7 @@ func loadStaticCommands() {
 		panic(err)
 	}
 	commands = cmnd
+	log.Printf("loaded %d static command(s) from %s\n", len(commands), absPath)
 }
 
 func saveStaticCommands() bool {
@@ -200,7 +210,11 @@ func saveStaticCommands() bool {
 	}
 	err = ioutil.WriteFile(commandJSON, s, 0o755)
 	if err != nil {
-		log.Printf("failed saving commands, error: %v\n", err)
+		absPath, absErr := filepath.Abs(commandJSON)
+		if absErr != nil {
+			absPath = commandJSON
+		}
+		log.Printf("failed saving commands to %s, error: %v\n", absPath, err)
 		return false
 	}
 	return true


### PR DESCRIPTION
Replace the underscore* sentinel workaround for deleting static commands with a dedicated !delcommand handler. The old approach silently mis-parsed on extra whitespace, falling into the add branch and overwriting the command with the literal text "_" instead of deleting it. 

Add/delete now share a whitespace-tolerant parser (strings.Fields) instead of strings.Split, which broke on double spaces.

Also log the resolved absolute path and entry count on every load/save of commands.json, so a deploy that silently resets state (e.g. missing persistent volume) is visible in logs instead of just "the delete didn't stick."