### PR TITLE
Modernize: Go 1.26, dependency bumps, CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# .git is deliberately NOT ignored: the Go toolchain stamps the commit into the
+# binary from it (see buildVersion).
+.github/
+.golangci.yaml
+.dockerignore
+Dockerfile
+README.md
+justfile
+modbot
+modbot.exe
+modbot-rotate
+commands.json
+coverage.out
+dist/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,25 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/modbot-cd.yaml
+++ b/.github/workflows/modbot-cd.yaml
@@ -2,30 +2,62 @@ name: modbot-cd
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+# never let two deploys race each other, and never cancel one mid-flight
+concurrency:
+  group: modbot-cd
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/memelabs/modbot/modbot
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Build and deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
-    - name: Docker login
-      env:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      run: docker login https://ghcr.io -u ${username} -p ${password}
-    - name: Build image
-      run: docker build . -t ghcr.io/memelabs/modbot/modbot:latest
-    - name: Publish image
-      run: docker push ghcr.io/memelabs/modbot/modbot:latest
-    - name: ssh-deploy for modbot
-      uses: appleboy/ssh-action@122f35dca5c7a216463c504741deb0de5b301953
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.KEY }}
-        script: |
-          ./hooks/modbot.sh
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          # "latest" is what the deploy hook pulls; the sha tag makes it
+          # possible to identify and roll back to a specific build
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: ssh-deploy for modbot
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          script: |
+            ./hooks/modbot.sh

--- a/.github/workflows/modbot-ci.yaml
+++ b/.github/workflows/modbot-ci.yaml
@@ -2,27 +2,74 @@ name: modbot-ci
 
 on:
   push:
-    branches:
-      - '*'
+    branches: ['**']
   pull_request:
-    branches:
-      - '*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.26
-      uses: actions/setup-go@v7
-      with:
-        go-version: 1.26
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-    - name: Test
-      run: go test -v ./...
-    - name: Build
-      run: go build -v .
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          # single source of truth for the Go version
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Check gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::not gofmt'd: $unformatted"
+            exit 1
+          fi
+
+      - name: Check go.mod is tidy
+        run: go mod tidy -diff
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      # build only, so a broken Dockerfile fails on the PR and not on deploy
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 modbot
 modbot.exe
+commands.json
+coverage.out
+dist/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,37 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose      # every http response body must be closed
+    - errorlint      # %w / errors.Is instead of == and %v
+    - gocritic
+    - misspell
+    - nilerr
+    - noctx          # no http requests without a context
+    - perfsprint
+    - revive
+    - unconvert
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+  settings:
+    revive:
+      rules:
+        - name: unused-parameter
+          # handlers must match dggchat's signatures, unused args are expected
+          disabled: true
+  exclusions:
+    presets:
+      - common-false-positives
+      - std-error-handling
+    rules:
+      # chat/mute/ban sends are best-effort; a failed send must not abort the
+      # parser, and dggchat already surfaces socket errors via its error handler
+      - linters: [errcheck]
+        source: 's\.(Send(Mute|Unmute|Ban|Unban|PrivateMessage))\('
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,36 @@
-FROM golang:alpine AS builder
-RUN apk --no-cache add ca-certificates
+# syntax=docker/dockerfile:1
+ARG GO_VERSION=1.26
 
-ENV CGO_ENABLED=0
+# Build on the native platform and cross-compile, which is far cheaper than
+# emulating the target platform under qemu.
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+
+# git lets the toolchain stamp the commit into the binary (see buildVersion)
+RUN apk add --no-cache ca-certificates git
 
 WORKDIR /build
 
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-COPY *.go ./
-RUN go build .
-WORKDIR /dist
-RUN cp /build/modbot .
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /dist/modbot .
 
 FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/MemeLabs/modbot" \
+      org.opencontainers.image.description="strims.gg chat moderation bot" \
+      org.opencontainers.image.licenses="MIT"
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /dist/modbot /
+COPY --from=builder /dist/modbot /modbot
 
 # Scraped over the `strims` docker network; deliberately not published to the host.
 EXPOSE 9090

--- a/README.md
+++ b/README.md
@@ -1,13 +1,45 @@
 # modbot
 
+Chat moderation bot for [strims.gg](https://strims.gg).
+
+### running
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `-cookie` | | jwt used for chat auth and API access (required) |
+| `-chat` | `wss://chat.strims.gg/ws` | chat websocket url |
+| `-api` | `https://strims.gg/api` | backend api base url |
+| `-log` | `/tmp/chatlog/chatlog.log` | chat log file, rotated on `SIGHUP` (see `modbot-rotate`) |
+| `-commands` | `commands.json` | static `!command` store, written by `!addcommand` |
+| `-attoken` | | angelthump admin token, needed for `!(un)drop` |
+| `-omdbkey` | | OMDb api key, needed for `!imdb` |
+| `-logonly` | `false` | reply to the log instead of chat, for debugging |
+| `-version` | | print the built commit and exit |
+
+See [monitoring](#monitoring) for `-metrics`, `-pinginterval` and `-healthcheck`.
+
+`SIGINT`/`SIGTERM` shut down cleanly; `SIGHUP` reopens the log file.
+
+### development
+
+Requires Go (version pinned in `go.mod`) and [`just`](https://github.com/casey/just).
+
+```
+just          # list recipes
+just check    # fmt, vet, test -race, lint, tidy -- what CI runs
+just build
+just image    # build the container image
+```
+
 ### mod commands
 
 | Command | Arguments | Example | Extra |
 | --- | --- | --- | ---- |
 | !modify | {service/username, username} [nsfw\|hidden\|afk\|promoted]... | !modify youtube/6n3pFFPSlW4 hidden !nsfw | To invert options (remove modifier), prefix with "!".
 | !rename | oldUsername newUsername | !rename ihatememes ilovememes | User has to reconnect after. Alternatively ban for 1 second.
-| !addcommand | [!]commandname [output\|\_] | !addcommand test i like tests | Using "\_" as output removes the given command.
-| !say | string | !say something nice |
+| !addcommand | [!]commandname output | !addcommand test i like tests | Overwrites an existing command of the same name.
+| !delcommand | [!]commandname | !delcommand test | Removes the given command.
+| !say | string | !say something nice | Always replies in public chat, even when issued over PM.
 | !mute | username | | Limited functionality, default 10m duration.
 | !nuke | string | !nuke badword123 | default 10m duration.
 | !nukeregex | regexp | !nukeregex (MiyanoHype ){10,} | default 10m duration.
@@ -46,4 +78,4 @@ cardinality, and it would make the metrics store a record of user behaviour.
 The image is `FROM scratch`, so `HEALTHCHECK` runs the binary's own
 `-healthcheck` mode. Change it alongside `-metrics` if you move the port.
 
-All mod-commands can also be issued via PMs to Bot. E.g. `/w Bot !modify youtube/6n3pFFPSlW4 hidden !nsfw`. Responses will be via normal chat though!
+All mod-commands can also be issued via PMs to Bot. E.g. `/w Bot !modify youtube/6n3pFFPSlW4 hidden !nsfw`. Replies come back on the channel the command arrived on, so a command sent over PM is answered over PM. `!say` is the exception and always speaks in public chat.

--- a/api.go
+++ b/api.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,7 +16,17 @@ import (
 const (
 	authCookieName    = "jwt"
 	apiRequestTimeout = 2 * time.Second
+	atRequestTimeout  = 4 * time.Second
 )
+
+// One client for the whole process: http.Client is safe for concurrent use and
+// pools connections, which a fresh client per call cannot do. Deadlines come
+// from the request context rather than Client.Timeout so callers can also be
+// cancelled on shutdown.
+var httpClient = &http.Client{}
+
+// errNotFound is returned when the upstream has no record of the requested user.
+var errNotFound = errors.New("user not found")
 
 type userInfo struct {
 	Username string `json:"username"`
@@ -40,146 +51,136 @@ type errorResp struct {
 	Error string `json:"error"`
 }
 
-func (b *bot) initHeaders(req *http.Request) *http.Request {
-	c := fmt.Sprintf("%s=%s", authCookieName, b.authCookie)
-	req.Header.Set("Cookie", c)
+// newRequest builds a backend request carrying the bot's auth cookie.
+func (b *bot) newRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Cookie", fmt.Sprintf("%s=%s", authCookieName, b.authCookie))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Bot", "botnet")
-	return req
+	return req, nil
+}
+
+// getJSON issues a GET against the backend and decodes the response into out.
+func (b *bot) getJSON(ctx context.Context, path string, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, apiRequestTimeout)
+	defer cancel()
+
+	req, err := b.newRequest(ctx, http.MethodGet, backendURL+path, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(out)
 }
 
 // Send rename request to backend.
-func (b *bot) renameUser(oldName string, newName string) error {
-	jsonStr := []byte(fmt.Sprintf(`{"username":"%s"}`, newName))
-	path := fmt.Sprintf("%s/admin/profiles/%s/username", backendURL, oldName)
-	req, err := http.NewRequest("POST", path, bytes.NewBuffer(jsonStr))
+func (b *bot) renameUser(ctx context.Context, oldName, newName string) error {
+	payload, err := json.Marshal(map[string]string{"username": newName})
 	if err != nil {
 		return err
 	}
-	req = b.initHeaders(req)
 
-	client := &http.Client{Timeout: apiRequestTimeout}
-	resp, err := client.Do(req)
+	ctx, cancel := context.WithTimeout(ctx, apiRequestTimeout)
+	defer cancel()
+
+	path := fmt.Sprintf("%s/admin/profiles/%s/username", backendURL, url.PathEscape(oldName))
+	req, err := b.newRequest(ctx, http.MethodPost, path, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != 200 {
-		unmarshalled := map[string]interface{}{}
-		if err := json.Unmarshal(body, &unmarshalled); err != nil {
-			return fmt.Errorf("failed to unmarshal response: %v", err)
-		}
-		msg, ok := unmarshalled["message"].(string)
-		if !ok {
-			return fmt.Errorf("status code %d, %s", resp.StatusCode, body)
-		}
-		return fmt.Errorf("%s", msg)
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
 	}
-	return nil
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var msg struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil || msg.Message == "" {
+		return fmt.Errorf("status code %d, %s", resp.StatusCode, body)
+	}
+	return errors.New(msg.Message)
 }
 
-// string because we don't want false default bools when marshaling
+// Pointers so an unset modifier is omitted while an explicit false is still sent.
 type streamModifier struct {
-	Nsfw     string `json:"nsfw,omitempty"`
-	Hidden   string `json:"hidden,omitempty"`
-	Afk      string `json:"afk,omitempty"`
-	Promoted string `json:"promoted,omitempty"`
+	Nsfw     *bool `json:"nsfw,omitempty"`
+	Hidden   *bool `json:"hidden,omitempty"`
+	Afk      *bool `json:"afk,omitempty"`
+	Promoted *bool `json:"promoted,omitempty"`
 }
 
 // Modify stream attributes (nsfw/hidden/...)
 // identifier can be a stream_path (simple string) or "{service}/{channel}"
-func (b *bot) setStreamAttributes(identifier string, modifier streamModifier) error {
-	jsonStr, err := json.Marshal(&modifier)
+func (b *bot) setStreamAttributes(ctx context.Context, identifier string, modifier streamModifier) error {
+	payload, err := json.Marshal(&modifier)
 	if err != nil {
 		return err
 	}
 
-	// backend does not like string-version of booleans,
-	// but we don't like structs with bools because omitempty
-	j := string(jsonStr[:])
-	j = strings.ReplaceAll(j, "\"true\"", "true")
-	j = strings.ReplaceAll(j, "\"false\"", "false")
+	ctx, cancel := context.WithTimeout(ctx, apiRequestTimeout)
+	defer cancel()
 
 	path := fmt.Sprintf("%s/admin/streams/%s", backendURL, identifier)
-	req, err := http.NewRequest("POST", path, bytes.NewBuffer([]byte(j)))
-	if err != nil {
-		return err
-	}
-	req = b.initHeaders(req)
-
-	client := &http.Client{Timeout: apiRequestTimeout}
-	resp, err := client.Do(req)
+	req, err := b.newRequest(ctx, http.MethodPost, path, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode == 200 {
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
 
 	// backend tells us a custom error message
 	var e errorResp
-	err = json.NewDecoder(resp.Body).Decode(&e)
-	if err != nil {
-		return err
+	if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+		return fmt.Errorf("status code %d: %w", resp.StatusCode, err)
 	}
 
 	return fmt.Errorf("error: %s", e.Error)
 }
 
-// build common get request...
-func (b *bot) buildGetRequest(path string) (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", backendURL, path), nil)
-	if err != nil {
-		return nil, err
-	}
-	req = b.initHeaders(req)
-	return req, nil
-}
-
 // get basic user info - to check if we are logged in and have correct rights
-func (b *bot) getProfileInfo() (userInfo, error) {
-	req, err := b.buildGetRequest("/profile")
-	if err != nil {
-		return userInfo{}, err
-	}
-	client := &http.Client{Timeout: apiRequestTimeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		return userInfo{}, err
-	}
-
+func (b *bot) getProfileInfo(ctx context.Context) (userInfo, error) {
 	var ui userInfo
-	err = json.NewDecoder(resp.Body).Decode(&ui)
-	if err != nil {
+	if err := b.getJSON(ctx, "/profile", &ui); err != nil {
 		return userInfo{}, err
 	}
-
 	return ui, nil
 }
 
 // Get list of current streams.
-func (b *bot) getStreamList() (streamData, error) {
+func (b *bot) getStreamList(ctx context.Context) (streamData, error) {
 	// empty path (/api) holds stream data...
-	req, err := b.buildGetRequest("")
-	if err != nil {
-		return streamData{}, err
-	}
-	client := &http.Client{Timeout: apiRequestTimeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		return streamData{}, err
-	}
-
 	var sd streamData
-	err = json.NewDecoder(resp.Body).Decode(&sd)
-	if err != nil {
+	if err := b.getJSON(ctx, "", &sd); err != nil {
 		return streamData{}, err
 	}
-
 	return sd, nil
 }
 
@@ -205,11 +206,15 @@ type omdbSearchResp struct {
 	Error    string `json:"Error"`
 }
 
-// issue a GET against OMDb with the given query params (apikey is added automatically)
-func omdbGet(params map[string]string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, omdbURL, nil)
+// omdbGet issues a GET against OMDb with the given query params and decodes the
+// result into out (apikey is added automatically).
+func omdbGet(ctx context.Context, params map[string]string, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, apiRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, omdbURL, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	q := req.URL.Query()
 	q.Set("apikey", omdbAPIKey)
@@ -218,46 +223,40 @@ func omdbGet(params map[string]string) (*http.Response, error) {
 	}
 	req.URL.RawQuery = q.Encode()
 
-	client := &http.Client{Timeout: apiRequestTimeout}
-	return client.Do(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(out)
 }
 
 // direct title lookup, scoped to a media type (movie/series) and optionally a release year
-func getIMDbInfo(query string, year string, mediaType string) (omdbResp, error) {
+func getIMDbInfo(ctx context.Context, query, year, mediaType string) (omdbResp, error) {
 	params := map[string]string{"t": query, "type": mediaType}
 	if year != "" {
 		params["y"] = year
 	}
-	resp, err := omdbGet(params)
-	if err != nil {
-		return omdbResp{}, err
-	}
-	defer resp.Body.Close()
 
 	var or omdbResp
-	if err := json.NewDecoder(resp.Body).Decode(&or); err != nil {
+	if err := omdbGet(ctx, params, &or); err != nil {
 		return omdbResp{}, err
 	}
 	if or.Response == "False" {
-		return omdbResp{}, fmt.Errorf("%s", or.Error)
+		return omdbResp{}, errors.New(or.Error)
 	}
 	return or, nil
 }
 
 // search titles matching the free-text query, scoped to a media type (movie/series)
-func searchIMDb(query string, mediaType string) (omdbSearchResp, error) {
-	resp, err := omdbGet(map[string]string{"s": query, "type": mediaType})
-	if err != nil {
-		return omdbSearchResp{}, err
-	}
-	defer resp.Body.Close()
-
+func searchIMDb(ctx context.Context, query, mediaType string) (omdbSearchResp, error) {
 	var sr omdbSearchResp
-	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+	if err := omdbGet(ctx, map[string]string{"s": query, "type": mediaType}, &sr); err != nil {
 		return omdbSearchResp{}, err
 	}
 	if sr.Response == "False" {
-		return omdbSearchResp{}, fmt.Errorf("%s", sr.Error)
+		return omdbSearchResp{}, errors.New(sr.Error)
 	}
 	return sr, nil
 }
@@ -279,39 +278,41 @@ type atData struct {
 }
 
 // interact with at backend
-func (b *bot) getATUserData(username string) (atData, error) {
-	path := fmt.Sprintf("https://api.angelthump.com/v3/streams/?username=%s", strings.ToLower(username))
-	req, err := http.NewRequest(http.MethodGet, path, nil)
-	if err != nil {
-		return atData{}, err
-	}
-	req = b.initHeaders(req)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Bot", "botnet")
+func (b *bot) getATUserData(ctx context.Context, username string) (atData, error) {
+	ctx, cancel := context.WithTimeout(ctx, atRequestTimeout)
+	defer cancel()
 
-	client := &http.Client{Timeout: apiRequestTimeout * 2}
-	resp, err := client.Do(req)
+	path := "https://api.angelthump.com/v3/streams/?username=" + url.QueryEscape(strings.ToLower(username))
+	req, err := b.newRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return atData{}, err
 	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return atData{}, err
+	}
+	defer resp.Body.Close()
 
 	// don't check status code, the backend doesn't report it correctly.
 	// if user does not exist, content type is text/html.
-	if !strings.Contains(resp.Header.Get("content-type"), "application/json") {
-		return atData{}, errors.New("user not found - 404")
+	if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
+		return atData{}, errNotFound
 	}
 
 	var atds []atData
-	err = json.NewDecoder(resp.Body).Decode(&atds)
-	if err != nil || len(atds) == 0 {
+	if err := json.NewDecoder(resp.Body).Decode(&atds); err != nil {
 		return atData{}, err
+	}
+	if len(atds) == 0 {
+		return atData{}, errNotFound
 	}
 
 	return atds[0], nil
 }
 
 // (un)ban AT user
-func (b *bot) banATuser(username string, reason string, ban bool) (string, error) {
+func (b *bot) banATuser(ctx context.Context, username, reason string, ban bool) (string, error) {
 	if reason == "" {
 		reason = "no reason provided"
 	}
@@ -321,38 +322,36 @@ func (b *bot) banATuser(username string, reason string, ban bool) (string, error
 		action = "ban"
 	}
 
-	path := fmt.Sprintf("https://streams.angelthump.com/v3/admin/%s", action)
+	ctx, cancel := context.WithTimeout(ctx, atRequestTimeout)
+	defer cancel()
 
-	req, err := http.NewRequest(http.MethodPost, path, strings.NewReader(
-		fmt.Sprintf("username=%s&reason=%s", username, url.QueryEscape(reason))))
+	form := url.Values{"username": {username}, "reason": {reason}}
+	path := "https://streams.angelthump.com/v3/admin/" + action
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("X-Bot", "botnet")
-	req.Header.Set("Authorization", fmt.Sprintf("key %s", atAdminToken))
+	req.Header.Set("Authorization", "key "+atAdminToken)
 
-	client := &http.Client{Timeout: apiRequestTimeout * 2}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
-	responseData, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var erro struct {
+	var result struct {
 		Error    bool   `json:"error"`
 		ErrorMSG string `json:"errorMSG"`
 	}
-	if err := json.Unmarshal(responseData, resp); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
 	}
 
-	if erro.Error {
-		return "", fmt.Errorf("failed to ban with: %q", erro.ErrorMSG)
+	if result.Error {
+		return "", fmt.Errorf("failed to %s with: %q", action, result.ErrorMSG)
 	}
 
 	return "success", nil

--- a/bot.go
+++ b/bot.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/MemeLabs/dggchat"
@@ -18,31 +20,47 @@ type message struct {
 	isPM      bool
 }
 
+// parser inspects an incoming message and optionally acts on it. The context is
+// scoped to handling that single message, so outbound API calls are cancelled
+// when the bot shuts down.
+type parser func(ctx context.Context, m message, s *dggchat.Session)
+
 type bot struct {
+	// Normally a context would be passed as an argument, but dggchat's handler
+	// signatures are fixed, so the shutdown context is carried on the bot and
+	// handed to parsers from there.
+	ctx             context.Context
 	log             []dggchat.Message
 	maxLogLines     int
-	parsers         []func(m message, s *dggchat.Session)
+	parsers         []parser
 	lastNukeVictims []string
 	randomizer      int
 	authCookie      string
 }
 
-func newBot(authCookie string, maxLogLines int) *bot {
+func newBot(ctx context.Context, authCookie string, maxLogLines int) *bot {
 	if maxLogLines < 0 {
 		maxLogLines = 0
 	}
 
-	b := bot{
-		log:         make([]dggchat.Message, maxLogLines),
+	return &bot{
+		ctx:         ctx,
+		log:         make([]dggchat.Message, 0, maxLogLines),
 		maxLogLines: maxLogLines,
 		randomizer:  0, // TODO workaround for dup msgs, remove me...
 		authCookie:  authCookie,
 	}
-	return &b
 }
 
-func (b *bot) addParser(p ...func(m message, s *dggchat.Session)) {
+func (b *bot) addParser(p ...parser) {
 	b.parsers = append(b.parsers, p...)
+}
+
+// dispatch runs every parser against the message.
+func (b *bot) dispatch(m message, s *dggchat.Session) {
+	for _, p := range b.parsers {
+		p(b.ctx, m, s)
+	}
 }
 
 func (b *bot) onMessage(m dggchat.Message, s *dggchat.Session) {
@@ -57,9 +75,7 @@ func (b *bot) onMessage(m dggchat.Message, s *dggchat.Session) {
 	setConnected(true)
 	recordMessage()
 
-	for _, p := range b.parsers {
-		p(message{Sender: m.Sender, Timestamp: m.Timestamp, Message: m.Message}, s)
-	}
+	b.dispatch(message{Sender: m.Sender, Timestamp: m.Timestamp, Message: m.Message}, s)
 }
 
 func (b *bot) onError(e string, s *dggchat.Session) {
@@ -95,31 +111,27 @@ func (b *bot) onPMHandler(m dggchat.PrivateMessage, s *dggchat.Session) {
 	log.Printf("[#] PM: %s: %s\n", m.User.Nick, m.Message)
 	setConnected(true)
 
-	if isMod(m.User) {
-		// handle PM as command, TODO: rules shouldn't be handled here...
-		msg := message{
-			Sender:    m.User,
-			Timestamp: m.Timestamp,
-			Message:   m.Message,
-			isPM:      true,
-		}
-
-		for _, p := range b.parsers {
-			p(msg, s)
-		}
+	if !isMod(m.User) {
+		return
 	}
+
+	// handle PM as command, TODO: rules shouldn't be handled here...
+	b.dispatch(message{
+		Sender:    m.User,
+		Timestamp: m.Timestamp,
+		Message:   m.Message,
+		isPM:      true,
+	}, s)
 }
 
 // return last n messsages for given user from log
 func (b *bot) getLastMessages(nick string, n int) []dggchat.Message {
 	var output []dggchat.Message
-	for i := len(b.log) - 1; i >= 0; i-- {
-
+	for _, msg := range slices.Backward(b.log) {
 		if len(output) >= n {
 			return output
 		}
 
-		msg := b.log[i]
 		if msg.Sender.Nick == nick {
 			output = append(output, msg)
 		}

--- a/commands.go
+++ b/commands.go
@@ -1,23 +1,19 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/MemeLabs/dggchat"
-)
-
-var (
-	mutex    sync.Mutex
-	commands = map[string]string{}
 )
 
 func isMod(user dggchat.User) bool {
@@ -59,19 +55,14 @@ func (b *bot) sendPublicDedupe(reply string, s *dggchat.Session) {
 	}
 }
 
-func (b *bot) staticMessage(m message, s *dggchat.Session) {
-	for command, response := range commands {
-		if strings.HasPrefix(m.Message, command) {
-
-			b.sendMessageDedupe(m, response, s)
-			// only handle the first match
-			return
-		}
+func (b *bot) staticMessage(_ context.Context, m message, s *dggchat.Session) {
+	if resp, ok := staticCommands.lookup(m.Message); ok {
+		b.sendMessageDedupe(m, resp, s)
 	}
 }
 
 // !nuke str, !nukeregex regexp
-func (b *bot) nuke(m message, s *dggchat.Session) {
+func (b *bot) nuke(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!nuke") {
 		return
 	}
@@ -83,7 +74,7 @@ func (b *bot) nuke(m message, s *dggchat.Session) {
 
 	isRegexNuke := parts[0] == "!nukeregex"
 	badstr := parts[1]
-	badregexp, err := regexp.Compile(badstr) // TODO when is error not nil??
+	badregexp, err := regexp.Compile(badstr)
 	if isRegexNuke && err != nil {
 		b.sendMessageDedupe(m, "regexp error", s)
 		return
@@ -94,7 +85,11 @@ func (b *bot) nuke(m message, s *dggchat.Session) {
 	victimNames := []string{}
 	// the command itself will be last in the log and caught, exclude that one.
 	// TODO: except if the command was issued via PM...
-	for _, m := range b.log[:len(b.log)-1] {
+	history := b.log
+	if len(history) > 0 {
+		history = history[:len(history)-1]
+	}
+	for _, m := range history {
 		// don't nuke mods.
 		if isMod(m.Sender) {
 			continue
@@ -121,14 +116,11 @@ func (b *bot) nuke(m message, s *dggchat.Session) {
 		// TODO print/send summary?
 	}
 
-	if b.lastNukeVictims == nil {
-		b.lastNukeVictims = []string{}
-	}
-	// combine array so we are able to undo all past nukes at once, if necessary
+	// combine slices so we are able to undo all past nukes at once, if necessary
 	b.lastNukeVictims = append(b.lastNukeVictims, victimNames...)
 }
 
-func (b *bot) sudoku(m message, s *dggchat.Session) {
+func (b *bot) sudoku(_ context.Context, m message, s *dggchat.Session) {
 	if !strings.HasPrefix(m.Message, "!sudoku") {
 		return
 	}
@@ -137,8 +129,8 @@ func (b *bot) sudoku(m message, s *dggchat.Session) {
 }
 
 // !aegis - undo (all) past nukes
-func (b *bot) aegis(m message, s *dggchat.Session) {
-	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!aegis") || b.lastNukeVictims == nil {
+func (b *bot) aegis(_ context.Context, m message, s *dggchat.Session) {
+	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!aegis") {
 		return
 	}
 
@@ -149,20 +141,18 @@ func (b *bot) aegis(m message, s *dggchat.Session) {
 }
 
 // !rename - change a chatter's username
-func (b *bot) rename(m message, s *dggchat.Session) {
+func (b *bot) rename(ctx context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!rename") {
 		return
 	}
 
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) < 3 {
 		return
 	}
 
-	oldName := parts[1]
-	newName := parts[2]
-	err := b.renameUser(oldName, newName)
-	if err != nil {
+	oldName, newName := parts[1], parts[2]
+	if err := b.renameUser(ctx, oldName, newName); err != nil {
 		msg := fmt.Sprintf("'%s' to '%s' by %s failed with '%s'",
 			oldName, newName, m.Sender.Nick, err.Error())
 		log.Printf("[##] rename: %s\n", msg)
@@ -181,7 +171,7 @@ func (b *bot) rename(m message, s *dggchat.Session) {
 }
 
 // !say - say a message
-func (b *bot) say(m message, s *dggchat.Session) {
+func (b *bot) say(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!say") {
 		return
 	}
@@ -195,16 +185,16 @@ func (b *bot) say(m message, s *dggchat.Session) {
 }
 
 // !mute - mute a chatter for a given time
-func (b *bot) mute(m message, s *dggchat.Session) {
+func (b *bot) mute(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!mute") {
 		return
 	}
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) < 2 {
 		return
 	}
 
-	var duration time.Duration = -1
+	duration := time.Duration(-1)
 	if len(parts) >= 3 {
 		dur, err := time.ParseDuration(parts[2])
 		if err != nil {
@@ -217,11 +207,11 @@ func (b *bot) mute(m message, s *dggchat.Session) {
 }
 
 // !unmute - unmute a chatter
-func (b *bot) unmute(m message, s *dggchat.Session) {
+func (b *bot) unmute(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!unmute") {
 		return
 	}
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) < 2 {
 		return
 	}
@@ -245,7 +235,7 @@ func normalizeCommandName(msg string, minParts int) (cmnd string, rest []string,
 }
 
 // !addcommand command response
-func (b *bot) addCommand(m message, s *dggchat.Session) {
+func (b *bot) addCommand(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!addcommand") {
 		return
 	}
@@ -256,19 +246,16 @@ func (b *bot) addCommand(m message, s *dggchat.Session) {
 	}
 	resp := strings.Join(respParts, " ")
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	commands[cmnd] = resp
-	success := saveStaticCommands()
-	if success {
-		b.sendMessageDedupe(m, fmt.Sprintf("added new command %s", cmnd), s)
+	if err := staticCommands.set(cmnd, resp); err != nil {
+		log.Printf("[##] failed adding command %s: %v\n", cmnd, err)
+		b.sendMessageDedupe(m, "failed saving command, check logs", s)
 		return
 	}
-	b.sendMessageDedupe(m, "failed saving command, check logs", s)
+	b.sendMessageDedupe(m, "added new command "+cmnd, s)
 }
 
 // !delcommand command
-func (b *bot) delCommand(m message, s *dggchat.Session) {
+func (b *bot) delCommand(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!delcommand") {
 		return
 	}
@@ -278,22 +265,19 @@ func (b *bot) delCommand(m message, s *dggchat.Session) {
 		return
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	delete(commands, cmnd)
-	success := saveStaticCommands()
-	if success {
-		b.sendMessageDedupe(m, fmt.Sprintf("deleted command %s if it existed", cmnd), s)
+	if err := staticCommands.delete(cmnd); err != nil {
+		log.Printf("[##] failed deleting command %s: %v\n", cmnd, err)
+		b.sendMessageDedupe(m, "failed saving command, check logs", s)
 		return
 	}
-	b.sendMessageDedupe(m, "failed saving command, check logs", s)
+	b.sendMessageDedupe(m, fmt.Sprintf("deleted command %s if it existed", cmnd), s)
 }
 
 var trailingYearRegexp = regexp.MustCompile(`^(.*\S)\s+(\d{4})$`)
 
 // !imdb [-tv|-s] title [year] -- look up a movie/show and print title (year) - rating - link
 // defaults to a direct movie lookup; -tv looks up a series instead; -s searches and lists matches
-func (b *bot) imdb(m message, s *dggchat.Session) {
+func (b *bot) imdb(ctx context.Context, m message, s *dggchat.Session) {
 	if !strings.HasPrefix(m.Message, "!imdb") {
 		return
 	}
@@ -303,9 +287,11 @@ func (b *bot) imdb(m message, s *dggchat.Session) {
 		return
 	}
 
+	const usage = "usage: !imdb [-tv|-s] <title> [year]"
+
 	parts := strings.SplitN(m.Message, " ", 2)
 	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
-		b.sendMessageDedupe(m, "usage: !imdb [-tv|-s] <title> [year]", s)
+		b.sendMessageDedupe(m, usage, s)
 		return
 	}
 	rest := strings.TrimSpace(parts[1])
@@ -315,28 +301,25 @@ func (b *bot) imdb(m message, s *dggchat.Session) {
 	switch {
 	case strings.HasPrefix(rest, "-tv "):
 		mediaType = "series"
-		rest = strings.TrimSpace(rest[len("-tv "):])
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "-tv "))
 	case strings.HasPrefix(rest, "-s "):
 		search = true
-		rest = strings.TrimSpace(rest[len("-s "):])
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "-s "))
 	}
 	if rest == "" {
-		b.sendMessageDedupe(m, "usage: !imdb [-tv|-s] <title> [year]", s)
+		b.sendMessageDedupe(m, usage, s)
 		return
 	}
 
 	if search {
-		sr, err := searchIMDb(rest, mediaType)
+		sr, err := searchIMDb(ctx, rest, mediaType)
 		if err != nil {
-			b.sendMessageDedupe(m, fmt.Sprintf("imdb: %s", err.Error()), s)
+			b.sendMessageDedupe(m, "imdb: "+err.Error(), s)
 			return
 		}
-		max := len(sr.Search)
-		if max > 5 {
-			max = 5
-		}
-		matches := make([]string, 0, max)
-		for _, item := range sr.Search[:max] {
+		results := sr.Search[:min(len(sr.Search), 5)]
+		matches := make([]string, 0, len(results))
+		for _, item := range results {
 			matches = append(matches, fmt.Sprintf("%s (%s)", item.Title, item.Year))
 		}
 		b.sendMessageDedupe(m, strings.Join(matches, ", "), s)
@@ -348,9 +331,9 @@ func (b *bot) imdb(m message, s *dggchat.Session) {
 		title, year = match[1], match[2]
 	}
 
-	info, err := getIMDbInfo(title, year, mediaType)
+	info, err := getIMDbInfo(ctx, title, year, mediaType)
 	if err != nil {
-		b.sendMessageDedupe(m, fmt.Sprintf("imdb: %s", err.Error()), s)
+		b.sendMessageDedupe(m, "imdb: "+err.Error(), s)
 		return
 	}
 	b.sendMessageDedupe(m, formatIMDbInfo(info), s)
@@ -361,102 +344,77 @@ func formatIMDbInfo(info omdbResp) string {
 	if rating == "" || rating == "N/A" {
 		rating = "no rating"
 	}
-	link := fmt.Sprintf("https://www.imdb.com/title/%s", info.ImdbID)
+	link := "https://www.imdb.com/title/" + info.ImdbID
 	return fmt.Sprintf("%s (%s) - %s - %s", info.Title, info.Year, rating, link)
 }
 
-// TOOD clean up...
+// TODO clean up...
 func isCommunityStream(path string) bool {
 	// "/twitch/test" it not. "/memer" is.
 	return strings.Count(path, "/") == 1 || strings.Contains(path, "angelthump")
 }
 
 // !stream or !strim(s) -- show top streams in chat
-func (b *bot) printTopStreams(m message, s *dggchat.Session) {
+func (b *bot) printTopStreams(ctx context.Context, m message, s *dggchat.Session) {
 	if !strings.HasPrefix(m.Message, "!stream") && !strings.HasPrefix(m.Message, "!strim") {
 		return
 	}
 
-	sd, err := b.getStreamList()
+	sd, err := b.getStreamList(ctx)
 	if err != nil {
 		log.Printf("%v\n", err)
 		b.sendMessageDedupe(m, "error getting api data", s)
 		return
 	}
 
-	// filter hidden streams
-	allStreams := sd.StreamList
-	filteredStreams := streamData{}
-	for _, v := range allStreams {
-		if !v.Hidden {
-			filteredStreams.StreamList = append(filteredStreams.StreamList, v)
+	// - assumption: API gives json data sorted by "rustlers".
+	// - community streams get preference, the rest fills up the remaining slots
+	// - data.URL has leading slash
+	var community, rest []string
+	for _, v := range sd.StreamList {
+		if v.Hidden {
+			continue
+		}
+		nsfw := ""
+		if v.Nsfw {
+			nsfw = " [nsfw]"
+		}
+		out := fmt.Sprintf("%d %s%s%s", v.Rustlers, websiteURL, v.URL, nsfw)
+		if isCommunityStream(v.URL) {
+			community = append(community, out)
+		} else {
+			rest = append(rest, out)
 		}
 	}
 
-	// handle case that less than 3 streams are being watched...
-	maxlen := len(filteredStreams.StreamList)
-	if maxlen == 0 {
+	top := slices.Concat(community, rest)
+	if len(top) == 0 {
 		b.sendMessageDedupe(m, "no streams are being watched", s)
 		return
 	}
-	if maxlen > 3 {
-		maxlen = 3
-	}
 
-	alreadyPrinted := 0
-	// - assumption: API gives json data sorted by "rustlers".
-	// - first pass: give community streams preference
-	// - data.URL has leading slash
-	for i := 0; i < len(filteredStreams.StreamList) && alreadyPrinted < maxlen; i++ {
-		data := filteredStreams.StreamList[i]
-		if isCommunityStream(data.URL) {
-			nsfw := ""
-			if data.Nsfw {
-				nsfw = " [nsfw]"
-			}
-			out := fmt.Sprintf("%d %s%s%s", data.Rustlers, websiteURL, data.URL, nsfw)
-			b.sendMessageDedupe(m, out, s)
-			alreadyPrinted++
-		}
-	}
-
-	// TODO clean me up...
-	for i := 0; alreadyPrinted < maxlen; i++ {
-		data := filteredStreams.StreamList[i]
-		if !isCommunityStream(data.URL) {
-			nsfw := ""
-			if data.Nsfw {
-				nsfw = " [nsfw]"
-			}
-			data := filteredStreams.StreamList[i]
-			out := fmt.Sprintf("%d %s%s%s", data.Rustlers, websiteURL, data.URL, nsfw)
-			b.sendMessageDedupe(m, out, s)
-			alreadyPrinted++
-		}
+	for _, out := range top[:min(len(top), 3)] {
+		b.sendMessageDedupe(m, out, s)
 	}
 }
 
-func parseModifiers(s []string) (streamModifier, error) {
+func parseModifiers(mods []string) (streamModifier, error) {
 	var sm streamModifier
 
-	for _, part := range s {
-		switch part {
+	for _, part := range mods {
+		// a leading "!" inverts the modifier: "!nsfw" clears the nsfw flag
+		name, negated := strings.CutPrefix(part, "!")
+		value := !negated
+
+		switch name {
 		case "nsfw":
-			sm.Nsfw = "true"
-		case "!nsfw":
-			sm.Nsfw = "false"
+			sm.Nsfw = &value
 		case "hidden":
-			sm.Hidden = "true"
-		case "!hidden":
-			sm.Hidden = "false"
+			sm.Hidden = &value
 		case "afk":
-			sm.Afk = "true"
-		case "!afk":
-			sm.Afk = "false"
+			sm.Afk = &value
 		case "promoted":
-			sm.Promoted = "true"
-		case "!promoted":
-			sm.Promoted = "false"
+			sm.Promoted = &value
 		default:
 			return streamModifier{}, fmt.Errorf("invalid modifier: '%s'", part)
 		}
@@ -465,14 +423,14 @@ func parseModifiers(s []string) (streamModifier, error) {
 	return sm, nil
 }
 
-func (b *bot) modifyStream(m message, s *dggchat.Session) {
+func (b *bot) modifyStream(ctx context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || !strings.HasPrefix(m.Message, "!modify") {
 		return
 	}
 
 	//                       parts[2:], ...
 	// !modify youtube/memes nsfw !hidden ...
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) < 3 {
 		return
 	}
@@ -485,8 +443,7 @@ func (b *bot) modifyStream(m message, s *dggchat.Session) {
 
 	identifier := parts[1]
 
-	err = b.setStreamAttributes(identifier, sm)
-	if err != nil {
+	if err := b.setStreamAttributes(ctx, identifier, sm); err != nil {
 		log.Printf("[##] modify: '%s' with modifier '%+v' by '%s' failed with '%s'\n",
 			identifier, sm, m.Sender.Nick, err.Error())
 
@@ -496,28 +453,26 @@ func (b *bot) modifyStream(m message, s *dggchat.Session) {
 	}
 	log.Printf("[##] modify: '%s' with modifier '%+v' by '%s' success!\n",
 		identifier, sm, m.Sender.Nick)
-	b.sendMessageDedupe(m, fmt.Sprintf("modify success %s", ominousEmote), s)
+	b.sendMessageDedupe(m, "modify success "+ominousEmote, s)
 }
 
 // !check ATusername
-func (b *bot) checkAT(m message, s *dggchat.Session) {
+func (b *bot) checkAT(ctx context.Context, m message, s *dggchat.Session) {
 	if !strings.HasPrefix(m.Message, "!check") {
 		return
 	}
 
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) != 2 {
 		return
 	}
 	username := parts[1]
 
-	atd, err := b.getATUserData(username)
+	atd, err := b.getATUserData(ctx, username)
 	if err != nil {
-		log.Printf("[##] checkAT error1: '%s'\n",
-			err.Error())
+		log.Printf("[##] checkAT error1: '%s'\n", err.Error())
 
-		// workaround... depends on content of error message
-		if strings.Contains(err.Error(), "404") {
+		if errors.Is(err, errNotFound) {
 			log.Printf("[##] check: not found\n")
 			return
 		}
@@ -527,10 +482,9 @@ func (b *bot) checkAT(m message, s *dggchat.Session) {
 	}
 
 	// additionally check strim data
-	sd, err := b.getStreamList()
+	sd, err := b.getStreamList(ctx)
 	if err != nil {
-		log.Printf("[##] checkAT error2: '%s'\n",
-			err.Error())
+		log.Printf("[##] checkAT error2: '%s'\n", err.Error())
 		b.sendMessageDedupe(m, "error getting api data", s)
 		return
 	}
@@ -566,7 +520,7 @@ func (b *bot) checkAT(m message, s *dggchat.Session) {
 }
 
 // !(un)drop atUser
-func (b *bot) dropAT(m message, s *dggchat.Session) {
+func (b *bot) dropAT(ctx context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || (!strings.HasPrefix(m.Message, "!drop") && !strings.HasPrefix(m.Message, "!undrop")) {
 		return
 	}
@@ -582,16 +536,16 @@ func (b *bot) dropAT(m message, s *dggchat.Session) {
 
 	if doBan && len(parts) < 3 {
 		s.SendPrivateMessage(m.Sender.Nick,
-			fmt.Sprintf("%s - please provide a ban reason", m.Sender.Nick))
+			m.Sender.Nick+" - please provide a ban reason")
 		return
 	}
 	if doBan {
 		reason = parts[2]
 	}
 
-	reply, err := b.banATuser(username, reason, doBan)
+	reply, err := b.banATuser(ctx, username, reason, doBan)
 	if err != nil {
-		log.Println(fmt.Sprintf("[##] drop error: '%s'", err.Error()))
+		log.Printf("[##] drop error: '%s'\n", err.Error())
 		return
 	}
 
@@ -613,7 +567,7 @@ func humanizeDuration(duration time.Duration) string {
 		{"day", days},
 		{"hour", hours},
 		{"min", minutes},
-		//{"sec", seconds},
+		// {"sec", seconds},
 	}
 
 	parts := []string{}
@@ -633,55 +587,54 @@ func humanizeDuration(duration time.Duration) string {
 }
 
 // !(un)ban -- ban a user
-func (b *bot) ban(m message, s *dggchat.Session) {
+func (b *bot) ban(_ context.Context, m message, s *dggchat.Session) {
 	if !isMod(m.Sender) || (!strings.HasPrefix(m.Message, "!ban") && !strings.HasPrefix(m.Message, "!unban")) {
 		return
 	}
 
-	parts := strings.Split(m.Message, " ")
+	parts := strings.Fields(m.Message)
 	if len(parts) < 2 {
 		return
 	}
 
-	if parts[0] == "!ban" {
+	switch parts[0] {
+	case "!ban":
 		reason := ""
 		if len(parts) == 3 {
 			reason = parts[2]
 		}
 		s.SendBan(parts[1], reason, 0, false)
-	} else if parts[0] == "!unban" {
+	case "!unban":
 		s.SendUnban(parts[1])
 	}
 }
 
-var errInputFormat = errors.New("invalid input format")
-var errInputBounds = errors.New("input out of bounds")
-var errResultRangeBounds = errors.New("result range out of bounds")
+var (
+	errInputFormat       = errors.New("invalid input format")
+	errInputBounds       = errors.New("input out of bounds")
+	errResultRangeBounds = errors.New("result range out of bounds")
+)
+
+// !roll [count]d<sides>[+/-modifier]
+var rollRegexp = regexp.MustCompile(`^!rolls?\s+(\d+)(?:d(\d+))?\s*([+\-]\s*\d+)?`)
 
 func computeRoll(input string) (int, error) {
-
-	// Define a regular expression to extract dice rolling information
-	regexPattern := `^!rolls?\s+(\d+)(?:d(\d+))?\s*([+\-]\s*\d+)?`
-	regex := regexp.MustCompile(regexPattern)
-
-	// Match the regular expression against the input string
-	matches := regex.FindStringSubmatch(input)
-
+	matches := rollRegexp.FindStringSubmatch(input)
 	if matches == nil {
 		return 0, fmt.Errorf("%w: %s", errInputFormat, input)
 	}
 
-	// Extract matched values
 	numDice, _ := strconv.Atoi(matches[1])
 	numSides, _ := strconv.Atoi(matches[2])
 
+	// bare "!roll 20" means one d20
 	if matches[2] == "" {
 		numSides = numDice
 		numDice = 1
 	}
 
-	modifier, _ := strconv.Atoi(matches[3])
-	checkMod := modifier != 0
+	// the regexp tolerates whitespace around the sign ("2d2 + 100"), Atoi does not
+	modifier, _ := strconv.Atoi(strings.ReplaceAll(matches[3], " ", ""))
 
 	if numSides <= 0 || numDice <= 0 || numDice > 1000 {
 		return 0, errInputBounds
@@ -693,33 +646,21 @@ func computeRoll(input string) (int, error) {
 		return 0, errResultRangeBounds
 	}
 
-	// Roll the dice
 	result := 0
-	for i := 0; i < numDice; i++ {
-		result += rand.Intn(numSides) + 1
+	for range numDice {
+		result += rand.IntN(numSides) + 1
 	}
 
-	// Apply the modifier if present
-	if checkMod {
-		result += modifier
-	}
-
-	return result, nil
+	return result + modifier, nil
 }
 
 // !roll sides [count] - roll dice
-func (b *bot) roll(m message, s *dggchat.Session) {
+func (b *bot) roll(_ context.Context, m message, s *dggchat.Session) {
 	if !strings.HasPrefix(m.Message, "!roll") {
 		return
 	}
 
-	parts := strings.Split(m.Message, " ")
-	if len(parts) < 2 {
-		return
-	}
-
-	var sum, err = computeRoll(m.Message)
-
+	sum, err := computeRoll(m.Message)
 	if err != nil {
 		return
 	}

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,30 +1,83 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseModifiers(t *testing.T) {
-	// correct modifiers
-	s1 := []string{"nsfw", "hidden"}
-	result, err := parseModifiers(s1)
-	if err != nil || result.Hidden != "true" || result.Nsfw != "true" {
-		t.Error("Error in modifier s1")
+	tests := []struct {
+		name    string
+		input   []string
+		want    map[string]bool
+		wantErr bool
+	}{
+		{
+			name:  "set two",
+			input: []string{"nsfw", "hidden"},
+			want:  map[string]bool{"nsfw": true, "hidden": true},
+		},
+		{
+			name:  "invert",
+			input: []string{"!nsfw", "promoted", "!afk"},
+			want:  map[string]bool{"nsfw": false, "promoted": true, "afk": false},
+		},
+		{
+			name:  "empty sends nothing",
+			input: nil,
+			want:  map[string]bool{},
+		},
+		{
+			name:    "unknown modifier",
+			input:   []string{"nsfw", "hide"},
+			wantErr: true,
+		},
+		{
+			name:    "inverted unknown modifier",
+			input:   []string{"!hide"},
+			wantErr: true,
+		},
 	}
 
-	// wrong modifier
-	s2 := []string{"nsfw", "hide"}
-	result, err = parseModifiers(s2)
-	if err == nil {
-		t.Error("Error in modifier s2")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseModifiers(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseModifiers(%v) = %+v, want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseModifiers(%v): %v", tc.input, err)
+			}
+
+			// unset modifiers must be omitted entirely, explicit false must be sent
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var marshaled map[string]bool
+			if err := json.Unmarshal(b, &marshaled); err != nil {
+				t.Fatalf("unmarshal %s: %v", b, err)
+			}
+			if len(marshaled) != len(tc.want) {
+				t.Fatalf("marshaled %s, want keys %v", b, tc.want)
+			}
+			for k, v := range tc.want {
+				if marshaled[k] != v {
+					t.Errorf("%s = %v, want %v (payload %s)", k, marshaled[k], v, b)
+				}
+			}
+		})
 	}
-	// fmt.Println(err.Error())
 }
 
 func TestComputeRoll(t *testing.T) {
-	testInputs := []struct {
+	tests := []struct {
 		input string
 		err   error
 	}{
@@ -43,13 +96,141 @@ func TestComputeRoll(t *testing.T) {
 		{input: "!roll 1d9223372036854775807"},
 		{input: "!roll 1d9223372036854775807+1", err: errResultRangeBounds},
 		{input: "!roll 9223372036854775807d1", err: errInputBounds},
+		{input: "!roll 0d6", err: errInputBounds},
+		{input: "!roll 1d0", err: errInputBounds},
+		{input: "!roll 1001d6", err: errInputBounds},
+		{input: "!roll", err: errInputFormat},
+		{input: "!roll d20", err: errInputFormat},
 	}
 
-	for _, c := range testInputs {
-		_, err := computeRoll(c.input)
-		if !errors.Is(err, c.err) {
-			fmt.Printf(`"%s": unexpected error %s\n`, c.input, err)
-			t.FailNow()
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if _, err := computeRoll(tc.input); !errors.Is(err, tc.err) {
+				t.Fatalf("computeRoll(%q) error = %v, want %v", tc.input, err, tc.err)
+			}
+		})
+	}
+}
+
+// A modifier separated from the dice by whitespace must still be applied.
+func TestComputeRollModifierSpacing(t *testing.T) {
+	for _, input := range []string{"!roll 1d1+100", "!roll 1d1 + 100", "!roll 1d1+ 100", "!roll 1d1 +100"} {
+		got, err := computeRoll(input)
+		if err != nil {
+			t.Fatalf("computeRoll(%q): %v", input, err)
+		}
+		if got != 101 {
+			t.Errorf("computeRoll(%q) = %d, want 101", input, got)
+		}
+	}
+}
+
+func TestComputeRollBounds(t *testing.T) {
+	for range 100 {
+		got, err := computeRoll("!roll 3d6")
+		if err != nil {
+			t.Fatalf("computeRoll: %v", err)
+		}
+		if got < 3 || got > 18 {
+			t.Fatalf("computeRoll(!roll 3d6) = %d, want 3..18", got)
+		}
+	}
+}
+
+func TestIsCommunityStream(t *testing.T) {
+	tests := map[string]bool{
+		"/memer":               true,
+		"/twitch/test":         false,
+		"/angelthump/streamer": true,
+		"/youtube/6n3pFFPSlW4": false,
+	}
+	for path, want := range tests {
+		if got := isCommunityStream(path); got != want {
+			t.Errorf("isCommunityStream(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestFormatIMDbInfo(t *testing.T) {
+	got := formatIMDbInfo(omdbResp{Title: "Dune", Year: "2021", ImdbID: "tt1160419", ImdbRating: "8.0"})
+	want := "Dune (2021) - 8.0 - https://www.imdb.com/title/tt1160419"
+	if got != want {
+		t.Errorf("formatIMDbInfo() = %q, want %q", got, want)
+	}
+
+	got = formatIMDbInfo(omdbResp{Title: "Dune", Year: "2021", ImdbID: "tt1160419", ImdbRating: "N/A"})
+	if !strings.Contains(got, "no rating") {
+		t.Errorf("formatIMDbInfo() = %q, want it to report no rating", got)
+	}
+}
+
+func TestStaticCommandStore(t *testing.T) {
+	path := t.TempDir() + "/commands.json"
+	s := newStaticCommandStore(path)
+
+	// a missing file is created rather than fatal
+	if err := s.load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := s.set("!test", "i like tests"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if resp, ok := s.lookup("!test with trailing words"); !ok || resp != "i like tests" {
+		t.Errorf("lookup = %q, %v; want %q, true", resp, ok, "i like tests")
+	}
+	if _, ok := s.lookup("!nope"); ok {
+		t.Error("lookup(!nope) matched")
+	}
+
+	// longest prefix wins, regardless of map ordering
+	if err := s.set("!testlonger", "more specific"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	for range 20 {
+		if resp, _ := s.lookup("!testlonger"); resp != "more specific" {
+			t.Fatalf("lookup(!testlonger) = %q, want %q", resp, "more specific")
+		}
+	}
+
+	// changes survive a reload from disk
+	reloaded := newStaticCommandStore(path)
+	if err := reloaded.load(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if resp, ok := reloaded.lookup("!test"); !ok || resp != "i like tests" {
+		t.Errorf("after reload lookup = %q, %v", resp, ok)
+	}
+
+	if err := s.delete("!test"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	reloaded = newStaticCommandStore(path)
+	if err := reloaded.load(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := reloaded.lookup("!test"); ok {
+		t.Error("deleted command survived reload")
+	}
+	if _, ok := reloaded.lookup("!testlonger"); !ok {
+		t.Error("delete removed an unrelated command")
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	tests := map[string]string{
+		"1h30m": "1hour 30mins",
+		"25h":   "1day 1hour",
+		"90s":   "1min",
+		"0s":    "",
+	}
+	for in, want := range tests {
+		d, err := time.ParseDuration(in)
+		if err != nil {
+			t.Fatalf("parse %q: %v", in, err)
+		}
+		if got := humanizeDuration(d); got != want {
+			t.Errorf("humanizeDuration(%s) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,14 @@
 module github.com/MemeLabs/modbot
 
 require (
-	github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906
+	github.com/MemeLabs/dggchat v0.0.0-20231206135306-915d599a11b8
 	github.com/prometheus/client_golang v1.24.1
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906 h1:srAWLSWDRcP9tdN2MgszP1ENb3VUPBWAFYtF+Jb1jPY=
-github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906/go.mod h1:r7pnEgdWZ0QU6R0wMHxbPoEsv1xe8vJ7lCM2mfPj/cs=
+github.com/MemeLabs/dggchat v0.0.0-20231206135306-915d599a11b8 h1:TJgkR8RNxhxgHFVS/OMbgUQ+pFwNtvwRPMSSk7uZ+XY=
+github.com/MemeLabs/dggchat v0.0.0-20231206135306-915d599a11b8/go.mod h1:1BVPRjmof6ltfx8zevcG7qvr7fVaEqJ20+ushSc/NbU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/justfile
+++ b/justfile
@@ -1,0 +1,43 @@
+golangci_version := "v2.12.2"
+
+_default:
+    @just --list
+
+# build the binary
+build:
+    go build -trimpath -o modbot .
+
+# run the full check suite, as CI does
+check: fmt vet test lint tidy
+
+fmt:
+    gofmt -l -w .
+
+vet:
+    go vet ./...
+
+test:
+    go test -race -count=1 ./...
+
+cover:
+    go test -race -count=1 -coverprofile=coverage.out ./...
+    go tool cover -func=coverage.out
+
+lint:
+    go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{golangci_version}} run ./...
+
+tidy:
+    go mod tidy -diff
+
+# apply available dependency updates
+bump:
+    go get -u ./...
+    go mod tidy
+
+# build the container image the same way CI does
+image tag="modbot:dev":
+    docker build -t {{tag}} .
+
+# run against chat in read-only mode; needs a jwt cookie
+run cookie="":
+    go run . -logonly -cookie "{{cookie}}"

--- a/main.go
+++ b/main.go
@@ -1,17 +1,16 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"path/filepath"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -29,21 +28,32 @@ var (
 	atAdminToken string
 	omdbAPIKey   string
 	logOnly      bool
-	logFile      *os.File
+	showVersion  bool
 	metricsAddr  string
 	pingInterval time.Duration
 	healthCheck  bool
+
+	logFile        *os.File
+	staticCommands *staticCommandStore
 )
 
 const (
 	websiteURL   = "strims.gg"
-	pollTime     = time.Second * 2
 	ominousEmote = "BOGGED"
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+// run holds the real body of main so that deferred cleanup still executes on
+// the error paths; log.Fatal in main would skip it.
+func run() error {
 	flag.StringVar(&authCookie, "cookie", "", "Cookie used for chat authentication and API access")
-	flag.StringVar(&chatPath, "path", "", "path to chat-gui")
+	// unused, kept so existing deploy invocations passing -path still start
+	flag.StringVar(&chatPath, "path", "", "path to chat-gui (unused)")
 	flag.StringVar(&chatURL, "chat", "wss://chat.strims.gg/ws", "ws(s)-url for chat")
 	flag.StringVar(&backendURL, "api", "https://strims.gg/api", "basic backend api path")
 	flag.StringVar(&logFileName, "log", "/tmp/chatlog/chatlog.log", "file to write messages to")
@@ -54,28 +64,42 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics", ":9090", "listen address for /metrics and /healthz")
 	flag.DurationVar(&pingInterval, "pinginterval", 30*time.Second, "how often to send a keepalive PING")
 	flag.BoolVar(&healthCheck, "healthcheck", false, "probe a running instance's /healthz and exit; used by the container HEALTHCHECK")
+	flag.BoolVar(&showVersion, "version", false, "print version and exit")
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(buildVersion())
+		return nil
+	}
 
 	if healthCheck {
 		if err := checkHealth(metricsAddr); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
-		return
+		return nil
 	}
 
-	loadStaticCommands()
+	staticCommands = newStaticCommandStore(commandJSON)
+	if err := staticCommands.load(); err != nil {
+		return err
+	}
 
 	serveMetrics(metricsAddr)
+
+	// cancelled on SIGINT/SIGTERM; parsers inherit it so in-flight API calls
+	// are dropped instead of holding up shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	// TODO dggchat lib isn't flexible with the cookie name, workaround...
 	dgg, err := dggchat.New(";jwt=" + authCookie)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	// init bot
-	b := newBot(authCookie, 250)
+	b := newBot(ctx, authCookie, 250)
 	b.addParser(
 		b.staticMessage,
 		b.nuke,
@@ -107,21 +131,20 @@ func main() {
 
 	u, err := url.Parse(chatURL)
 	if err != nil {
-		log.Fatalln(err)
+		return fmt.Errorf("parsing chat url %q: %w", chatURL, err)
 	}
 	dgg.SetURL(*u)
 
-	err = dgg.Open()
-	if err != nil {
-		log.Fatalln(err)
+	if err := dgg.Open(); err != nil {
+		return fmt.Errorf("connecting to chat: %w", err)
 	}
 	setConnected(true)
-	debuglogger.Println("[##] connected...")
+	debuglogger.Printf("[##] connected... (version %s)\n", buildVersion())
 	defer dgg.Close()
 
 	go pinger(dgg, pingInterval)
 
-	info, err := b.getProfileInfo()
+	info, err := b.getProfileInfo(ctx)
 	if err != nil {
 		debuglogger.Printf("userinfo: %s\n", err.Error())
 	} else {
@@ -129,115 +152,81 @@ func main() {
 	}
 
 	// log to file and stdout
-	logFile = reOpenLog()
+	logFile, err = reOpenLog()
+	if err != nil {
+		return err
+	}
 	log.Println("[##] Restart")
 
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	// logrotate signals us out-of-band; SIGINT/SIGTERM land on ctx instead.
+	hup := make(chan os.Signal, 1)
+	signal.Notify(hup, syscall.SIGHUP)
+	defer signal.Stop(hup)
 
 	if logOnly {
 		debuglogger.Println("[##] started in logonly mode.")
 	}
 	debuglogger.Println("[##] waiting for signals...")
-	for {
-		sig := <-signals
-		switch sig {
 
+	for {
+		select {
 		// handle logrotate request from daemon
-		case syscall.SIGHUP:
+		case <-hup:
 			log.Println("[##] signal: handling SIGHUP")
-			err = logFile.Close()
-			if err != nil {
-				panic(err)
+			if err := logFile.Close(); err != nil {
+				log.Printf("[##] error closing logfile: %s\n", err)
 			}
-			logFile = reOpenLog()
+			if logFile, err = reOpenLog(); err != nil {
+				return err
+			}
 
 		// exit on interrupt
-		case syscall.SIGTERM:
-			fallthrough
-		case syscall.SIGINT:
+		case <-ctx.Done():
 			log.Println("[##] signal: handling SIGINT/SIGTERM")
-			err = logFile.Close()
-			if err != nil {
-				log.Printf("[##] error in cleanup: %s\n", err.Error())
+			if err := logFile.Close(); err != nil {
+				log.Printf("[##] error in cleanup: %s\n", err)
 			}
-			os.Exit(1)
+			return nil
 		}
 	}
 }
 
-func reOpenLog() *os.File {
-	dir, _ := path.Split(logFileName)
-	if !fileExists(dir) {
+func reOpenLog() (*os.File, error) {
+	if dir := filepath.Dir(logFileName); dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			panic(err)
+			return nil, fmt.Errorf("creating log directory %s: %w", dir, err)
 		}
 	}
 
-	f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o755)
+	f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("opening log file %s: %w", logFileName, err)
 	}
-	mw := io.MultiWriter(os.Stdout, f)
-	log.SetOutput(mw)
-	return f
+	log.SetOutput(io.MultiWriter(os.Stdout, f))
+	return f, nil
 }
 
-func fileExists(name string) bool {
-	if _, err := os.Stat(name); err != nil {
-		if os.IsNotExist(err) {
-			return false
+// buildVersion reports the VCS revision stamped into the binary by the Go
+// toolchain, so a running bot can be traced back to a commit.
+func buildVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+
+	var revision, dirty string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			if s.Value == "true" {
+				dirty = "-dirty"
+			}
 		}
 	}
-	return true
-}
-
-func loadStaticCommands() {
-	// resolved to an absolute path so deploy logs show exactly which file/volume
-	// is in play -- the flag default is a bare relative name and silently
-	// follows whatever the process's CWD happens to be on a given deploy.
-	absPath, err := filepath.Abs(commandJSON)
-	if err != nil {
-		absPath = commandJSON
+	if revision == "" {
+		return info.GoVersion
 	}
-
-	if !fileExists(commandJSON) {
-		log.Printf("commands file %s not found, creating empty one\n", absPath)
-		err := ioutil.WriteFile(commandJSON, []byte("{}"), 0o755)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	b, err := ioutil.ReadFile(commandJSON)
-	if err != nil {
-		panic(err)
-	}
-	var cmnd map[string]string
-	err = json.Unmarshal(b, &cmnd)
-	if err != nil {
-		panic(err)
-	}
-	commands = cmnd
-	log.Printf("loaded %d static command(s) from %s\n", len(commands), absPath)
-}
-
-func saveStaticCommands() bool {
-	s, err := json.MarshalIndent(commands, "", "\t")
-	if err != nil {
-		commandPersistFailures.Inc()
-		log.Printf("failed marshaling commands, error: %v\n", err)
-		return false
-	}
-	err = ioutil.WriteFile(commandJSON, s, 0o755)
-	if err != nil {
-		commandPersistFailures.Inc()
-		absPath, absErr := filepath.Abs(commandJSON)
-		if absErr != nil {
-			absPath = commandJSON
-		}
-		log.Printf("failed saving commands to %s, error: %v\n", absPath, err)
-		return false
-	}
-	return true
+	return fmt.Sprintf("%s%s %s", revision[:min(len(revision), 12)], dirty, info.GoVersion)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -104,8 +105,15 @@ func checkHealth(addr string) error {
 		return fmt.Errorf("bad metrics address %q: %w", addr, err)
 	}
 
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%s/healthz", port))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:"+port+"/healthz", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -13,8 +13,10 @@ func TestHealthzReflectsConnectionState(t *testing.T) {
 	serveMetrics(addr)
 
 	var err error
-	for i := 0; i < 100; i++ {
-		if _, err = http.Get("http://" + addr + "/healthz"); err == nil {
+	for range 100 {
+		var resp *http.Response
+		if resp, err = get(t, "http://"+addr+"/healthz"); err == nil {
+			resp.Body.Close()
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -33,7 +35,7 @@ func TestHealthzReflectsConnectionState(t *testing.T) {
 		t.Errorf("checkHealth() failed while connected: %v", err)
 	}
 
-	resp, err := http.Get("http://" + addr + "/metrics")
+	resp, err := get(t, "http://"+addr+"/metrics")
 	if err != nil {
 		t.Fatalf("GET /metrics: %v", err)
 	}
@@ -41,6 +43,17 @@ func TestHealthzReflectsConnectionState(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("GET /metrics = %s, want 200", resp.Status)
 	}
+}
+
+// get issues a GET bound to the test's context.
+func get(t *testing.T, url string) (*http.Response, error) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("building request for %s: %v", url, err)
+	}
+	return http.DefaultClient.Do(req)
 }
 
 func TestCheckHealthRejectsBadAddress(t *testing.T) {

--- a/rules.go
+++ b/rules.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"context"
 	"log"
 	"strings"
 	"time"
@@ -9,31 +9,36 @@ import (
 	"github.com/MemeLabs/dggchat"
 )
 
+const (
+	shortMsgLen    = 2
+	shortMsgWindow = time.Hour
+	shortMsgLimit  = 5
+)
+
 // Prevent repeated posting of short messages.
-func (b *bot) noShortMsgSpam(m message, s *dggchat.Session) {
+func (b *bot) noShortMsgSpam(_ context.Context, m message, s *dggchat.Session) {
 	// only proceed if the current message is "bad"
-	if len(m.Message) > 2 {
+	if len(m.Message) > shortMsgLen {
 		return
 	}
 
-	// ["time", "msg"]
 	lastmsgs := b.getLastMessages(m.Sender.Nick, 10)
 	badmsgs := []string{}
-	badmsgcount := 0
-	now := time.Now().Add(time.Duration(-60) * time.Minute)
+	cutoff := time.Now().Add(-shortMsgWindow)
 
 	// check how many of the last messages were too short and they are within the
 	// past hour.
 	for _, msg := range lastmsgs {
-		if len(msg.Message) <= 2 && now.Before(msg.Timestamp) {
-			badmsgcount++
+		if len(msg.Message) <= shortMsgLen && cutoff.Before(msg.Timestamp) {
 			badmsgs = append(badmsgs, msg.Message)
 		}
 	}
 
-	if badmsgcount >= 5 {
+	if len(badmsgs) >= shortMsgLimit {
 		log.Printf("[##] single char mute with '%s' for '%s'\n", strings.Join(badmsgs, ", "), m.Sender.Nick)
 		s.SendMute(m.Sender.Nick, -1)
-		s.SendMessage(fmt.Sprintf("%s - too many short messages", m.Sender.Nick))
+		if err := s.SendMessage(m.Sender.Nick + " - too many short messages"); err != nil {
+			log.Printf("[##] send error: %s\n", err.Error())
+		}
 	}
 }

--- a/store.go
+++ b/store.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// staticCommandStore holds the mod-defined "!command -> response" pairs, backed
+// by a JSON file on disk. It is read on every chat message and written only by
+// !addcommand, hence the RWMutex.
+type staticCommandStore struct {
+	mu   sync.RWMutex
+	path string
+	// resolved so deploy logs show exactly which file/volume is in play -- the
+	// flag default is a bare relative name and silently follows whatever the
+	// process's CWD happens to be on a given deploy.
+	absPath string
+	cmds    map[string]string
+}
+
+func newStaticCommandStore(path string) *staticCommandStore {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return &staticCommandStore{path: path, absPath: absPath, cmds: map[string]string{}}
+}
+
+// load reads the backing file, creating an empty one if it does not exist yet.
+func (s *staticCommandStore) load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		log.Printf("commands file %s not found, creating empty one\n", s.absPath)
+		s.cmds = map[string]string{}
+		return s.save()
+	}
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", s.absPath, err)
+	}
+
+	cmds := map[string]string{}
+	if err := json.Unmarshal(b, &cmds); err != nil {
+		return fmt.Errorf("parsing %s: %w", s.absPath, err)
+	}
+	s.cmds = cmds
+	log.Printf("loaded %d static command(s) from %s\n", len(s.cmds), s.absPath)
+	return nil
+}
+
+// save writes the store to disk atomically. Callers must hold the write lock.
+// A failure here means an acknowledged !addcommand was lost, so it is counted.
+func (s *staticCommandStore) save() error {
+	if err := s.writeFile(); err != nil {
+		commandPersistFailures.Inc()
+		return err
+	}
+	return nil
+}
+
+func (s *staticCommandStore) writeFile() error {
+	b, err := json.MarshalIndent(s.cmds, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshaling commands: %w", err)
+	}
+
+	// Write to a temp file in the same directory and rename, so a crash
+	// mid-write cannot leave a truncated commands file behind.
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".commands-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing %s: %w", tmp.Name(), err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", tmp.Name(), err)
+	}
+	if err := os.Chmod(tmp.Name(), 0o644); err != nil {
+		return fmt.Errorf("chmod %s: %w", tmp.Name(), err)
+	}
+	if err := os.Rename(tmp.Name(), s.path); err != nil {
+		return fmt.Errorf("renaming into %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// lookup returns the response for the longest command that msg starts with.
+// Longest-prefix wins so that "!foo" and "!foobar" resolve deterministically;
+// ranging over the map picked an arbitrary one.
+func (s *staticCommandStore) lookup(msg string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var best, resp string
+	for cmd, r := range s.cmds {
+		if strings.HasPrefix(msg, cmd) && len(cmd) > len(best) {
+			best, resp = cmd, r
+		}
+	}
+	return resp, best != ""
+}
+
+func (s *staticCommandStore) set(cmd, resp string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cmds[cmd] = resp
+	return s.save()
+}
+
+func (s *staticCommandStore) delete(cmd string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.cmds, cmd)
+	return s.save()
+}


### PR DESCRIPTION
Brings modbot up to current Go and current GitHub Actions, and fixes a handful of bugs found while reading the code. Three commits, each independently buildable.

Rebased onto master after #64 and the PM-reply/delcommand work landed — see "Rebase notes" at the bottom for how the overlapping changes were merged.

## Behavior changes worth knowing about

**`!drop` was always reporting failure.** `banATuser` unmarshalled the response into the `*http.Response` instead of its error struct, so the call always errored. The ban itself went through — only the reply was broken. Mods will now get a success reply where they previously saw an error. Worth a heads-up so it doesn't read as a regression.

Also:
- `!check` no longer proceeds on zero-valued data when angelthump returns an empty result
- `!roll 2d2 + 100` now applies the modifier — `Atoi` can't parse `"+ 100"`, so a spaced modifier was silently dropped
- Static commands match longest-prefix-first; previously `!foo` vs `!foobar` resolved arbitrarily depending on map iteration order
- SIGTERM exits 0 instead of 1

## Fixes

- Six response bodies were never closed, leaking a connection on every `!check`, `!stream`, `!imdb`, `!modify` and `!rename`
- `renameUser` built its JSON body with `Sprintf`; usernames are now marshalled and path-escaped
- The static command map was read without a lock on every chat message

## Modernization

- Drop `io/ioutil`, `math/rand` → `math/rand/v2`, range-over-int, `min`/`max`, `slices.Backward`/`Concat`, `strings.CutPrefix`
- One shared `http.Client` with `NewRequestWithContext`, replacing a client built per call. A shutdown context is plumbed from `main` through the parser signature, so in-flight API calls are cancelled on SIGTERM rather than holding up shutdown.
- `main` split into `main`/`run` so `log.Fatal` no longer skips deferred cleanup; `signal.NotifyContext` for INT/TERM, SIGHUP still rotates the log
- Static commands moved behind an `RWMutex` in `store.go` with temp-file-and-rename writes
- Stream modifiers are `*bool` with `omitempty` instead of strings string-replaced back into booleans. Same wire format, now covered by a test.
- New `-version` flag reporting the commit via `debug.ReadBuildInfo`

## Deps

dggchat 2020 snapshot → 2023-12-06, gorilla/websocket 1.4.2 → 1.5.3. No API changes needed. Prometheus from #64 is untouched.

## CI/CD

- CI adds vet, `-race` + coverage, golangci-lint (pinned v2.12.2), `gofmt` and `go mod tidy -diff` checks, and a Dockerfile build so a broken image fails here rather than on deploy. Go version now comes from `go.mod` instead of being hardcoded in two places. Adds `permissions: contents: read` and concurrency cancellation.
- CD moves to buildx with GHA layer caching and pushes a `sha-` tag alongside `latest`, so a bad deploy can be rolled back to a known image. `latest` still points where the deploy hook expects. Token scoped to `packages: write`, deploys grouped so two can't race, and the ssh-action pin moved off a commit from **February 2020** to v1.2.5.
- Dockerfile pins its base, uses BuildKit cache mounts, and cross-compiles via `TARGETOS`/`TARGETARCH` instead of emulating under qemu. With `-trimpath -ldflags="-s -w"` the image is ~7MB. `EXPOSE 9090` and the `HEALTHCHECK` from #64 are preserved.
- Dependabot now weekly and grouped, covering github-actions and docker in addition to gomod

Adds a `justfile` (`just check` mirrors CI) and a README section for flags and dev workflow.

## Rebase notes

Master and this branch both changed the parser signature. They were merged rather than either side winning:

- **Parser signature** is now `func(ctx context.Context, m message, s *dggchat.Session)` — master's `message`/`isPM` reply routing plus this branch's context. `sendMessageDedupe`/`sendPublicDedupe` and the `!m.isPM` guard in `rename` are kept as-is.
- **`!delcommand`** and `normalizeCommandName` are kept as master wrote them, re-pointed at the new store instead of the `commands` map + `mutex`.
- **Persistence diagnostics** from `b439eac` (absolute path, entry count) moved into `store.go`, and `commandPersistFailures.Inc()` now fires from a single place covering both add and delete.
- **Three lint findings in the new metrics code** are fixed rather than suppressed, since this PR is what introduces the linter: `checkHealth` and the metrics test now use `NewRequestWithContext` (noctx), and the test's poll loop closes its response body (bodyclose).
- **README** had two lines that went stale on master: `!addcommand` still documented the `_` deletion sentinel that `b439eac` replaced, and the footer still said PM replies come back in public chat. Both corrected, and `!delcommand` documented.

## Verification

`go build`, `go vet`, `golangci-lint run`, `go test -race`, and `go mod tidy -diff` all clean on the rebased tree. Container image builds and `-version` reports the commit. I also ran the pinned golangci-lint **release** binary against the repo to confirm the CI lint job won't trip over Go 1.26.

## Deliberately not done

- **`log` → `log/slog`**: `chatlog.log` is the production chat log and `modbot-rotate` keys off it. Changing that output format is a separate decision.
- **Non-root container user**: worth doing, but `hooks/modbot.sh` lives outside this repo and I couldn't check what owns the mounted chatlog dir. A wrong guess breaks the deploy silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)